### PR TITLE
Filter ipaddress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@
 /uploads
 .env
 /**/templates/*
-/.idea/workspace.xml
+.idea/**/workspace.xml
+.idea/**/tasks.xml
 credentials.json

--- a/.idea/xlsx-creator-web.iml
+++ b/.idea/xlsx-creator-web.iml
@@ -913,6 +913,25 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
+      <library name="maxminddb (vbundled(0.1.22)) [path][gem]" type="rubylib">
+        <properties>
+          <option name="version" value="4" />
+        </properties>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/maxminddb-0.1.22/lib" />
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/maxminddb-0.1.22/spec" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/maxminddb-0.1.22/lib" />
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/maxminddb-0.1.22/spec" />
+        </SOURCES>
+        <excluded>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/maxminddb-0.1.22/spec" />
+        </excluded>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
       <library name="memoist (vbundled(0.16.2)) [path][gem]" type="rubylib">
         <properties>
           <option name="version" value="4" />

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "rack-cors"
 gem "commonmarker"
 gem 'sorcery'
 gem 'google-cloud-storage'
+gem 'maxminddb'
+gem 'rack-attack'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
+    maxminddb (0.1.22)
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -208,6 +209,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
+    rack-attack (6.6.1)
+      rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-test (2.0.2)
@@ -339,8 +342,10 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jwt
+  maxminddb
   mysql2 (~> 0.5)
   puma (~> 5.0)
+  rack-attack
   rack-cors
   rails (~> 7.0.4)
   rspec-rails (~> 6.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,7 @@ module ExcelCreator
     # config.eager_load_paths << Rails.root.join("extras")
     config.middleware.use ActionDispatch::Cookies
     config.i18n.default_locale = :ja
+    config.x.maxminddb = MaxMindDB.new("#{Rails.root}/db/GeoLite2-Country.mmdb")
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,0 +1,12 @@
+class Rack::Attack
+  blocklist('prohibit access from outside Japan') do |req|
+    ip = req.env["action_dispatch.remote_ip"].to_s
+    ret = Rails.configuration.x.maxminddb.lookup(ip)
+    if ret.found? == false
+      puts "ip address not found"
+      next false
+    end
+    puts "check country iso code : #{ret.country.iso_code}"
+    ret.country.iso_code != "JP"
+  end
+end


### PR DESCRIPTION
日本以外からのアクセスを禁止した。
以下のgem、リソースを使用。
- [rack-attack](https://github.com/rack/rack-attack)
アクセス元IPに対するホワイトリスト、ブラックリストの設定や指定のページの表示制限などを設定するgem
- [maxminddb](https://github.com/yhirose/maxminddb)
IPアドレスを基にどの国からのアクセスかを判定するgem/db。

今回は判定したISO国コードが`JP`以外の国からのアクセスの場合、403を返すようにした。

### メモ
ローカルでテスト時、`127.0.0.1`からのアクセスとなるが、この場合は国が判定できない。
ISO国コードが取得できない場合は、許可している。
別途ホワイトリストを設定し、`127.0.0.1`の時は許可、とした方が良いかもしれない。

