### PR TITLE
cookie設定時にhttponly属性とsecure属性を追加

### DIFF
--- a/app/services/sign_in_service.rb
+++ b/app/services/sign_in_service.rb
@@ -7,7 +7,8 @@ module SignInService
       return render :new, status: :unprocessable_entity
     end
     # JWTをCookieにセット
-    cookies[:token] = token
+    # ローカルではsecure: falseでテストしたい為、Cloud Runにデプロイする際に環境変数でtrueとする
+    cookies[:token] = {value: token, httponly: true, secure: ENV.fetch("RAILS_IS_DEPLOYED") == "true"}
     return redirect_to root_path
   end
 end


### PR DESCRIPTION
認証時に発行するcookie[token]について、`httponly`属性と`secure`属性を追加
secure属性についてはlocalhostでテストする際に使用できない為、環境変数に応じて有効無効を切り替える
