### PR TITLE
時刻の表示を日本形式に変更

### DIFF
--- a/.idea/xlsx-creator-web.iml
+++ b/.idea/xlsx-creator-web.iml
@@ -1370,6 +1370,25 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
+      <library name="rack-attack (vbundled(6.6.1)) [path][gem]" type="rubylib">
+        <properties>
+          <option name="version" value="4" />
+        </properties>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/rack-attack-6.6.1/lib" />
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/rack-attack-6.6.1/spec" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/rack-attack-6.6.1/lib" />
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/rack-attack-6.6.1/spec" />
+        </SOURCES>
+        <excluded>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/3.1.0/gems/rack-attack-6.6.1/spec" />
+        </excluded>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
       <library name="rack-cors (vbundled(1.1.1)) [path][gem]" type="rubylib">
         <properties>
           <option name="version" value="4" />

--- a/app/views/home/new.html.erb
+++ b/app/views/home/new.html.erb
@@ -26,7 +26,7 @@
             <%= form.description %>
           </td>
           <td>
-            <%= form.updated_at %>
+            <%= l form.updated_at, format: :long %>
           </td>
           <td>
             <div class="d-flex justify-content-around">

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module ExcelCreator
     # config.eager_load_paths << Rails.root.join("extras")
     config.middleware.use ActionDispatch::Cookies
     config.i18n.default_locale = :ja
+    config.time_zone = 'Asia/Tokyo'
     config.x.maxminddb = MaxMindDB.new("#{Rails.root}/db/GeoLite2-Country.mmdb")
     config.middleware.use Rack::Attack
   end


### PR DESCRIPTION
テンプレート一覧に表示する更新時刻のフォーマットを`yyyy/mm/ss hh:mm`に変更
- `locale/ja.yml`で指定されたフォーマットを使用する形で対応
修正時に参考にしたURL
[https://qiita.com/jnchito/items/831654253fb8a958ec25]()
- `locale/ja.yml`は日本用のメッセージや、日本用の時刻表示フォーマットが公開されている為、そちらを利用
[https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml]()
